### PR TITLE
<img360-tour> FireFoxSupport

### DIFF
--- a/src/img360-tour.js
+++ b/src/img360-tour.js
@@ -84,7 +84,11 @@ class Img360Tour extends HTMLElement {
       })
     })
 
-    observer.observe(this, {childList: true})
+    observer.observe(this, {
+      childList: true,
+      characterData: true,
+      subtree: true
+    });
 
     const hasDevice = device !== null;
 
@@ -239,6 +243,8 @@ class Img360Tour extends HTMLElement {
         }
       }, false);
     }
+
+    traverse(this.children);
   }
 
   _getVRDevice() {


### PR DESCRIPTION
On FireFox it seems that when `connectedCallback()` is fired child elements are already added while on Chrome child elements are added after the callback.

So observing child element addition since the callback is fired misses the chance to traverse child elements on FireFox. Instead I need to traverse child elements in the callback function.