### PR TITLE
Add http-server module for local test

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,13 @@ $ npm install
 $ npm run build
 ```
 
+### How to locally run
+
+```sh
+$ npm run start
+# local server boots up. Access http://localhost:8080/examples/index.html on your browser.
+```
+
 ## Similar projects
 
 - [model-viewer](https://github.com/GoogleWebComponents/model-viewer)

--- a/package.json
+++ b/package.json
@@ -2,9 +2,11 @@
   "name": "immersive-custom-elements",
   "version": "0.0.1",
   "scripts": {
-    "build": "rollup -c"
+    "build": "rollup -c",
+    "start": "http-server . -p 8080 -c-1"
   },
   "devDependencies": {
+    "http-server": "^0.11.1",
     "rollup": "^1.12.3",
     "rollup-plugin-node-resolve": "^5.0.0"
   },


### PR DESCRIPTION
User can locally run web components with `$ npm run start`.