### PR TITLE
Change aspect from 4:3 to 16:9 in examples and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add the link to `immersive-custom-elements.js` with `<script>` tag. You can down
     <script src="https://rawcdn.githack.com/MozillaReality/immersive-custom-elements/v0.1.0/build/immersive-custom-elements.js"></script>
   </head>
   <body>
-    <img-360 src="https://rawcdn.githack.com/MozillaReality/immersive-custom-elements/v0.1.0/assets/img-360/landscape-3531355_1920.jpg" width="640" height="480"></img-360>
+    <img-360 src="https://rawcdn.githack.com/MozillaReality/immersive-custom-elements/v0.1.0/assets/img-360/landscape-3531355_1920.jpg" width="640" height="360"></img-360>
   </body>
 </html>
 ```
@@ -55,7 +55,7 @@ If you have any new custom element tag ideas, join [this brainstorming thread](h
 Displays an interactive 360 degree photo.
 
 ```javascript
-<img-360 src="imagefile.jpg" width="640" height="480"></img-360>
+<img-360 src="imagefile.jpg" width="640" height="360"></img-360>
 ```
 
 | attribute | type | description |
@@ -71,7 +71,7 @@ Displays an interactive 360 degree photo.
 Displays an interactive 360 degree video.
 
 ```javascript
-<video-360 src="video.mp4" width="640" height="480"></video>
+<video-360 src="video.mp4" width="640" height="360"></video>
 ```
 
 | attribute | type | description |
@@ -89,7 +89,7 @@ Displays an interactive 360 degree video.
 Displays a set of interactive 360 degree photos. You can switch between photos by gazing at white plane for three seconds.
 
 ```javascript
-<img-360-tour width="640" height="480">
+<img-360-tour width="640" height="360">
   <img-360-tour-item src="imagefile1.jpg"></img-360-tour-item>
   <img-360-tour-item src="imagefile2.jpg"></img-360-tour-item>
   <img-360-tour-item src="imagefile3.jpg"></img-360-tour-item>

--- a/examples/img-360-tour.html
+++ b/examples/img-360-tour.html
@@ -6,7 +6,7 @@
   <body>
     <script src="../build/immersive-custom-elements.js"></script>
     <h1>&lt;img-360-tour&gt;</h1>
-    <img-360-tour width="480" height="320">
+    <img-360-tour width="480" height="270">
       <img-360-tour-item src="../assets/img-360/landscape-3531355_1920.jpg"></img-360-tour-item>
       <img-360-tour-item src="../assets/img-360/winter-2383930_1920.jpg"></img-360-tour-item>
     </img-360-tour>
@@ -16,7 +16,7 @@ Image author: <a href="https://pixabay.com/ja/photos/%E5%86%AC-%E3%83%91%E3%83%8
     </div>
     <h2>Code</h2>
     <pre>
-&lt;img-360-tour width="480" height="320"&gt;
+&lt;img-360-tour width="480" height="270"&gt;
   &lt;img-360-tour-item src="../assets/img-360/landscape-3531355_1920.jpg"&gt;&lt;/img-360-tour-item&gt;
   &lt;img-360-tour-item src="../assets/img-360/winter-2383930_1920.jpg"&gt;&lt;/img-360-tour-item&gt;
 &lt;/img-360-tour&gt;

--- a/examples/img-360.html
+++ b/examples/img-360.html
@@ -6,13 +6,13 @@
   <body>
     <script src="../build/immersive-custom-elements.js"></script>
     <h1>&lt;img-360&gt;</h1>
-    <img-360 src="../assets/img-360/landscape-3531355_1920.jpg" width="480" height="320"></img-360>
+    <img-360 src="../assets/img-360/landscape-3531355_1920.jpg" width="480" height="270"></img-360>
     <div class="copyright">
 Image author: <a href="https://pixabay.com/ja/photos/%E9%A2%A8%E6%99%AF-%E3%83%9E%E3%82%A6%E3%83%B3%E3%83%88-360%C2%B0-%E9%9B%AA-3531355/" target="_blank">tomazolivier</a> (Licensed under <a href="https://pixabay.com/service/license/" target="_blank">Pixabay License</a>)
     </div>
     <h2>Code</h2>
     <pre>
-&lt;img-360 src="../assets/img-360/landscape-3531355_1920.jpg" width="480" height="320"&gt;&lt;/img-360&gt;
+&lt;img-360 src="../assets/img-360/landscape-3531355_1920.jpg" width="480" height="270"&gt;&lt;/img-360&gt;
     </pre>
   </body>
 </html>

--- a/examples/video-360.html
+++ b/examples/video-360.html
@@ -6,13 +6,13 @@
   <body>
     <script src="../build/immersive-custom-elements.js"></script>
     <h1>&lt;video-360&gt;</h1>
-    <video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="320" loop></video-360>
+    <video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" loop></video-360>
     <div class="copyright">
 Video author: <a href="https://360rtc.com/videos/uzabeachsky006/" target="_blank">あーる・てぃー・しー合同会社</a> (Licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>)
     </div>
     <h2>Code</h2>
     <pre>
-&lt;video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="320" loop&gt;&lt;/video-360&gt;
+&lt;video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" loop&gt;&lt;/video-360&gt;
     </pre>
   </body>
 </html>


### PR DESCRIPTION
This PR changes aspect from 4:3 to 16:9 examples and readme because I think 16:9 fits better to immersive contents.