### PR TITLE
Audio support for video-360

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Displays an interactive 360 degree photo.
 
 ### \<video-360\>
 
-Displays an interactive 360 degree video.
+Plays an interactive 360 degree video. Click video to start playing.
 
 ```javascript
 <video-360 src="video.mp4" width="640" height="360"></video>
@@ -79,7 +79,9 @@ Displays an interactive 360 degree video.
 | src | strings | Path to video file |
 | width | number | element width |
 | height | number | element height |
-| loop | - | video loops if specified |
+| loop | - | video loops if defined |
+| muted | - | the audio output of the video is muted if defined |
+| autoplay | - | video automatically starts playing if defined |
 
 ![GitHub Logo](screenshots/video-360.gif)
 

--- a/examples/video-360.html
+++ b/examples/video-360.html
@@ -6,13 +6,13 @@
   <body>
     <script src="../build/immersive-custom-elements.js"></script>
     <h1>&lt;video-360&gt;</h1>
-    <video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" loop></video-360>
+    <video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" muted autoplay loop></video-360>
     <div class="copyright">
 Video author: <a href="https://360rtc.com/videos/uzabeachsky006/" target="_blank">あーる・てぃー・しー合同会社</a> (Licensed under <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank">CC BY 4.0</a>)
     </div>
     <h2>Code</h2>
     <pre>
-&lt;video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" loop&gt;&lt;/video-360&gt;
+&lt;video-360 src="../assets/video-360/uzabeachsky_006.mp4" width="480" height="270" muted autoplay loop&gt;&lt;/video-360&gt;
     </pre>
   </body>
 </html>


### PR DESCRIPTION
Resolves #30

This PR adds audio support for `<video-360>`. Currently `<video-360>` sets `video.muted = true` as hardcoded but this PR enables users to configure it and to sound audio.

Also this PR adds `autoplay` and `muted` attributes to `<video-360>`.