### PR TITLE
Support DeviceOrientation controls

### DIFF
--- a/src/elements/img-360.js
+++ b/src/elements/img-360.js
@@ -4,17 +4,24 @@ import {
   WebGLRenderer
 } from 'three';
 import {OrbitControls} from 'three/examples/jsm/controls/OrbitControls';
+import {
+  DeviceOrientationControlsWrapper,
+  DeviceOrientationHelper
+} from '../utils/deviceorientation-helper';
 import {VRHelper} from '../utils/vr-helper';
 import {THREEHelper} from '../utils/three-helper';
 
 class Img360 extends HTMLElement {
   connectedCallback() {
-    VRHelper.getVRDevice().then(device => {
-      this._initialize(device);
+    Promise.all([
+      VRHelper.getVRDevice(),
+      DeviceOrientationHelper.hasDeviceOrientation()
+    ]).then(array => {
+      this._initialize(array[0], array[1]);
     });
   }
 
-  _initialize(device) {
+  _initialize(device, hasDeviceOrientation) {
     const hasDevice = device !== null;
 
 
@@ -59,11 +66,12 @@ class Img360 extends HTMLElement {
 
     // Three.js camera controls
 
-    const controls = new OrbitControls(camera, renderer.domElement);
+    const controls = hasDeviceOrientation
+      ? new DeviceOrientationControlsWrapper(camera)
+      : new OrbitControls(camera, renderer.domElement);
     controls.addEventListener('change', event => {
       render();
     });
-
 
     // VR / Fullscreen
 

--- a/src/utils/deviceorientation-helper.js
+++ b/src/utils/deviceorientation-helper.js
@@ -1,0 +1,84 @@
+import {
+  EventDispatcher
+} from 'three';
+import {
+  DeviceOrientationControls
+} from 'three/examples/jsm/controls/DeviceOrientationControls';
+
+class DeviceOrientationControlsWrapper extends EventDispatcher {
+  constructor(camera) {
+    super();
+
+    this.controls = new DeviceOrientationControls(camera);
+    this.prohibiting = false;
+
+    const onChange = (event) => {
+      if (!this.controls.enabled || this.prohibiting) return;
+      this.controls.update();
+      this.dispatchEvent({type: 'change'});
+
+      // Ignoring the event in the same animation frame.
+      // because this event is fired too often.
+      this.prohibiting = true;
+      requestAnimationFrame(() => { this.prohibiting = false; });
+    };
+
+    window.addEventListener('orientationchange', onChange, false);
+    window.addEventListener('deviceorientation', onChange, false);
+  }
+
+  get enabled() {
+    return this.controls.enabled;
+  }
+
+  set enabled(enabled) {
+    this.controls.enabled = enabled;
+  }
+}
+
+class DeviceOrientationHelper {
+  static hasDeviceOrientation() {
+    return new Promise((resolve) => {
+      let detecting = true;
+
+      const onOrientationChange = () => {
+        if (detecting) {
+          detecting = false;
+          removeEventListeners();
+          resolve(true);
+        }
+      };
+
+      const onDeviceOrientation = (event) => {
+        if (detecting) {
+          detecting = false;
+          removeEventListeners();
+          resolve(event.alpha === null ? false : true);
+        }
+      };
+
+      const removeEventListeners = () => {
+        window.removeEventListener('orientationchange', onOrientationChange, false);
+        window.removeEventListener('deviceorientation', onDeviceOrientation, false);
+      };
+
+      window.addEventListener('orientationchange', onOrientationChange, false);
+      window.addEventListener('deviceorientation', onDeviceOrientation, false);
+
+      // Determining device orientation isn't supported if
+      // orientation event isn't called in 100ms.
+      setTimeout(() => {
+        if (detecting) {
+          detecting = false;
+          removeEventListeners();
+          resolve(false);
+        }
+      }, 100);
+    });
+  }
+}
+
+export {
+  DeviceOrientationControlsWrapper,
+  DeviceOrientationHelper
+};


### PR DESCRIPTION
This PR resolves #68.

If browser supports and enables DeviceOrientation the elements use `DeviceOrientationControls`. Otherwise they keep using `OrbitControls`.
