### PR TITLE
Hide VR/Fullscreen button if the browser does not support either one

### DIFF
--- a/src/utils/vr-helper.js
+++ b/src/utils/vr-helper.js
@@ -65,7 +65,7 @@
     if (element.fullscreenEnabled !== undefined) {
       return element.fullscreenEnabled;
     }
-    if (element.webkitFullscreenEnabld !== undefined) {
+    if (element.webkitFullscreenEnabled !== undefined) {
       return element.webkitFullscreenEnabled;
     }
     if (element.mozFullScreenEnabled !== undefined) {


### PR DESCRIPTION
From https://github.com/MozillaReality/immersive-custom-elements/issues/67#issuecomment-525002558

This PR hides VR/fullscreen button in case if no VR device and no fullscreen API. Currently iPhone doesn't support Fullscreen API. It may be confusing to such platforms if we display "fullscreen" button.