### PR TITLE
Add playsinline attribute to video-360 for iOS

### DIFF
--- a/src/elements/video-360.js
+++ b/src/elements/video-360.js
@@ -96,6 +96,10 @@ class Video360 extends HTMLElement {
     video.loop = loop;
     video.muted = muted;
 
+    // This line is necessary for iOS.
+    // Otherwise video plays in fullscreen mode as regular video.
+    video.setAttribute('playsinline', true);
+
     // Seems like explicit video.load() call is needed
     // for some (mobile?) platforms.
     video.load();


### PR DESCRIPTION
This PR resolves #78.

We needed to set playsinline attribute in video to play inline on iOS.

https://webkit.org/blog/6784/new-video-policies-for-ios/

> On iPhone, <video playsinline> elements will now be allowed to play inline, and will not automatically enter fullscreen mode when playback begins.
<video> elements without playsinline attributes will continue to require fullscreen mode for playback on iPhone.